### PR TITLE
specs+ci: fix openspec validation and pin it to cairn's version

### DIFF
--- a/.github/workflows/openspec-validate.yml
+++ b/.github/workflows/openspec-validate.yml
@@ -24,7 +24,12 @@ jobs:
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
+      # Use cairn's OWN pinned openspec (.#openspec), not `nixpkgs#openspec`.
+      # The latter floated to the runner's registry and validated with a newer,
+      # stricter openspec than cairn ships — so specs passed locally and failed
+      # here. This pins CI to the same version your machines get; it moves when
+      # flake.lock moves.
       - name: Validate all specs
         run: |
           echo "📐 Validating OpenSpec specs..."
-          nix run nixpkgs#openspec -- validate --specs --no-interactive
+          nix run .#openspec -- validate --specs --no-interactive

--- a/openspec/specs/desktop/spec.md
+++ b/openspec/specs/desktop/spec.md
@@ -189,7 +189,7 @@ PWA applications (PIM, Immich, generic apps) SHALL be defined via a central `cai
 
 ### Requirement: File Manager Integration
 
-Dolphin is configured to use Ghostty as its terminal emulator, and KDE Activities (unused in Niri) are hidden from the UI.
+Dolphin SHALL be configured to use Ghostty as its terminal emulator, and KDE Activities (unused in Niri) SHALL be hidden from the UI.
 
 #### Scenario: User opens terminal from Dolphin context menu
 
@@ -207,7 +207,7 @@ Dolphin is configured to use Ghostty as its terminal emulator, and KDE Activitie
 
 ### Requirement: Flatpak Installation Handler
 
-Clicking "Install" on the Flathub website triggers a transparent, terminal-based installation flow.
+Clicking "Install" on the Flathub website SHALL trigger a transparent, terminal-based installation flow.
 
 #### Scenario: User installs app from Flathub
 
@@ -236,7 +236,7 @@ Clicking "Install" on the Flathub website triggers a transparent, terminal-based
 
 ### Requirement: Drop-down Terminal Identity
 
-The drop-down terminal uses a proper Cairn app-id and does not appear in the DMS dock.
+The drop-down terminal SHALL use a proper Cairn app-id and SHALL NOT appear in the DMS dock.
 
 #### Scenario: User toggles drop-down terminal
 
@@ -337,6 +337,8 @@ Hoppscotch SHALL be included as a default PWA in `pkgs/pwa-apps/pwa-defs.nix`, w
 
 ### Requirement: GStreamer is not included by default
 
+GStreamer SHALL NOT be included in the default package set.
+
 **Rationale**: GStreamer causes boot instability due to glib symbol mismatches and race conditions with PipeWire. Media playback uses mpv with FFmpeg decoding instead.
 
 #### Scenario: User needs GStreamer for specific Qt apps
@@ -362,7 +364,7 @@ Hoppscotch SHALL be included as a default PWA in `pkgs/pwa-apps/pwa-defs.nix`, w
 
 ### Requirement: SSD-Consistent Application Selection
 
-All primary desktop applications respect the compositor's `prefer-no-csd` setting. Brief utility windows (screenshot annotation, audio control) are exempt. The normie profile uses `prefer-no-csd = false`, so applications draw client-side decorations (titlebars with window controls).
+All primary desktop applications SHALL respect the compositor's `prefer-no-csd` setting. Brief utility windows (screenshot annotation, audio control) are exempt. The normie profile uses `prefer-no-csd = false`, so applications draw client-side decorations (titlebars with window controls).
 
 #### Scenario: User opens any default application (standard profile)
 
@@ -445,7 +447,7 @@ The init script SHALL prompt for each user's profile during user collection inst
 
 ### Requirement: Default Text Editor
 
-Mousepad serves as the default text editor, providing syntax highlighting and clean editing without IDE-weight features.
+Mousepad SHALL serve as the default text editor, providing syntax highlighting and clean editing without IDE-weight features.
 
 #### Scenario: User opens text editor via keybind
 
@@ -464,7 +466,7 @@ Mousepad serves as the default text editor, providing syntax highlighting and cl
 
 ### Requirement: GPU Resource Correlation Awareness
 
-Desktop session stability correlates with GPU memory state; Cairn documents this relationship to aid troubleshooting.
+Desktop session stability correlates with GPU memory state; Cairn SHALL document this relationship to aid troubleshooting.
 
 #### Scenario: Login after heavy LLM inference
 

--- a/openspec/specs/pim/spec.md
+++ b/openspec/specs/pim/spec.md
@@ -220,7 +220,7 @@ PIM module SHALL support multi-host Tailnet deployments via role-based configura
 
 ### Requirement: AI Module Dependency (Server Role Only)
 
-PIM server role REQUIRES the AI module to be enabled.
+PIM server role MUST have the AI module enabled.
 
 #### Scenario: Server role without AI
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -29,8 +29,13 @@ in
   perSystem =
     { system, pkgs, ... }:
     {
-      # Automatically export all custom packages
-      packages = lib.genAttrs packageNames (name: pkgs.${name});
+      # Automatically export all custom packages, plus openspec so CI (and
+      # `nix run .#openspec`) validate specs with the SAME version cairn ships,
+      # not whatever floats into the runner's `nixpkgs#` registry. Kills the
+      # skew where a check goes green locally and red in CI.
+      packages = lib.genAttrs packageNames (name: pkgs.${name}) // {
+        openspec = pkgs.openspec;
+      };
 
       _module.args.pkgs = import inputs.nixpkgs {
         inherit system;


### PR DESCRIPTION
Two commits. First fixes the red check, second makes sure it can't sneak up like this again.

## 1. Give every requirement an RFC 2119 keyword

Eight requirements in `desktop` and `pim` stated their rule in plain prose with no SHALL/MUST:

- **desktop**: File Manager Integration, Flatpak Installation Handler, Drop-down Terminal Identity, GStreamer-not-default, SSD-Consistent Application Selection, Default Text Editor, GPU Resource Correlation Awareness
- **pim**: AI Module Dependency (said "REQUIRES")

Reworded each to use SHALL/MUST without changing meaning.

## 2. Pin CI to cairn's own openspec

Root cause of the red check: the job ran `nix run nixpkgs#openspec`, which resolves against the **runner's** registry (`nixpkgs-weekly`) — openspec **1.11.0**, which promoted the "requirement needs SHALL/MUST" rule from a warning to a hard failure. cairn pins nixpkgs at openspec **1.10.0**, which only warns. Two different openspecs → passes locally, fails in CI.

Fix: expose openspec as a flake output (`.#openspec`, from cairn's own nixpkgs) and point the workflow at it. CI now validates with the exact version your machines run, and only moves when `flake.lock` moves.

Verified: `nix run .#openspec -- validate --specs --no-interactive` → 15 passed, 0 failed. Both specs also pass under `--strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)